### PR TITLE
Fix npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test"
   ],
   "bin": {
-    "jsonld-context-parse": "jsonld-context-parse"
+    "jsonld-context-parse": "bin/jsonld-context-parse.js"
   },
   "devDependencies": {
     "@types/isomorphic-fetch": "^0.0.34",


### PR DESCRIPTION
When running `npm i`, npm gives an error because the bin file cannot be found. Changed the package.json slightly so that it can find the bin file.

```
 npm i jsonld-context-parser
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

npm ERR! path .../node_modules/jsonld-context-parser/jsonld-context-parse
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '.../node_modules/jsonld-context-parser/jsonld-context-parse'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

```