### PR TITLE
Parse imported contexts

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -880,6 +880,9 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
         ERROR_CODES.INVALID_CONTEXT_ENTRY);
     }
 
+    // Containers have to be converted into hash values the same way as for the importing context
+    // Otherwise context validation will fail for container values
+    this.containersToHash(importContext);
     return importContext;
   }
 

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -3181,6 +3181,20 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
         }, { processingMode: 1.0 })).rejects.toThrow(new ErrorCoded('Context importing is not supported in JSON-LD 1.0',
           ERROR_CODES.INVALID_CONTEXT_ENTRY));
       });
+
+      it('should convert containers to hash values after loading context', async () => {
+        const parsed = await parser.loadImportContext('http://example.org/simple_with_container.jsonld');
+
+        expect(parsed).toEqual({
+          rdfs: "https://www.w3.org/2000/01/rdf-schema#",
+          label: {
+            "@id": "rdfs:label",
+            "@container": {
+              "@language": true,
+            },
+          },
+        });
+      });
     });
 
   });

--- a/test/http/simple_with_container.jsonld
+++ b/test/http/simple_with_container.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": 
+  {
+    "rdfs": "https://www.w3.org/2000/01/rdf-schema#",
+    "label": {
+      "@id": "rdfs:label",
+      "@container": "@language"
+    }
+  }
+}


### PR DESCRIPTION
Parse imported contexts, not only their "parent" context. Parsing ensures several things (normalization, transformation of containers to hash values) that is also important for imported contexts.