### PR TITLE
Fix/base resolving

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -617,8 +617,7 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
               parentContext[key] = {...parentContext[key]};
               delete parentContext[key]['@context'];
               await this.parse(value['@context'],
-                { ...options, external: false, parentContext, ignoreProtection: true, ignoreRemoteScopedContexts: true, 
-                  ignoreScopedContexts: true });
+                { ...options, external: false, parentContext, ignoreProtection: true, ignoreRemoteScopedContexts: true, ignoreScopedContexts: true });
             } catch (e) {
               throw new ErrorCoded(e.message, ERROR_CODES.INVALID_SCOPED_CONTEXT);
             }

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -617,14 +617,15 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
               parentContext[key] = {...parentContext[key]};
               delete parentContext[key]['@context'];
               await this.parse(value['@context'],
-                { ...options, parentContext, ignoreProtection: true, ignoreRemoteScopedContexts: true, ignoreScopedContexts: true });
+                { ...options, external: false, parentContext, ignoreProtection: true, ignoreRemoteScopedContexts: true, 
+                  ignoreScopedContexts: true });
             } catch (e) {
               throw new ErrorCoded(e.message, ERROR_CODES.INVALID_SCOPED_CONTEXT);
             }
           }
 
           value['@context'] = (await this.parse(value['@context'],
-            { ...options, minimalProcessing: true, ignoreRemoteScopedContexts: true, parentContext: context }))
+            { ...options, external: false, minimalProcessing: true, ignoreRemoteScopedContexts: true, parentContext: context }))
             .getContextRaw();
         }
       }

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -1688,6 +1688,8 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
           .resolves.toEqual(new JsonLdContextNormalized({
             prop: {
               '@context': {
+                "@__baseDocument": true,
+                "@base": "http://example.org/remote_cyclic_scoped_indirect_1.jsonld",
                 prop: {
                   '@context': 'http://example.org/remote_cyclic_scoped_indirect_1.jsonld',
                   '@id': 'ex:prop',
@@ -1927,6 +1929,8 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
           .resolves.toEqual(new JsonLdContextNormalized({
             prop: {
               '@context': {
+                "@__baseDocument": true,
+                "@base": "http://example.org/remote_cyclic_scoped_indirect_1.jsonld",
                 prop: {
                   '@context': 'http://example.org/remote_cyclic_scoped_indirect_1.jsonld',
                   '@id': 'ex:prop',


### PR DESCRIPTION
This PR allows the base field of nested contexts in external contexts to resolve. While base parameters at the root of an external context should be omitted, the spec is not fully clear on base parameters in nested contexts. The jsonld-playground also resolves these in external contexts.