### PR TITLE
Move packages to prevent circular dependency

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -4,7 +4,7 @@ import {ERROR_CODES, ErrorCoded} from "./ErrorCoded";
 import {FetchDocumentLoader} from "./FetchDocumentLoader";
 import {IDocumentLoader} from "./IDocumentLoader";
 import {IJsonLdContext, IJsonLdContextNormalizedRaw, IPrefixValue, JsonLdContext} from "./JsonLdContext";
-import {JsonLdContextNormalized} from "./JsonLdContextNormalized";
+import {JsonLdContextNormalized, defaultExpandOptions, IExpandOptions} from "./JsonLdContextNormalized";
 import {Util} from "./Util";
 
 // tslint:disable-next-line:no-var-requires
@@ -981,24 +981,3 @@ export interface IParseOptions {
   ignoreScopedContexts?: boolean;
 }
 
-export interface IExpandOptions {
-  /**
-   * If compact IRI prefixes can end with any kind of character in simple term definitions,
-   * instead of only the default gen-delim characters (:,/,?,#,[,],@).
-   */
-  allowPrefixNonGenDelims: boolean;
-  /**
-   * If compact IRI prefixes ending with a non-gen-delim character
-   * can be forced as a prefix using @prefix: true.
-   */
-  allowPrefixForcing: boolean;
-  /**
-   * If @vocab values are allowed contain IRIs relative to @base.
-   */
-  allowVocabRelativeToBase: boolean;
-}
-export const defaultExpandOptions: IExpandOptions = {
-  allowPrefixForcing: true,
-  allowPrefixNonGenDelims: false,
-  allowVocabRelativeToBase: true,
-};

--- a/lib/JsonLdContextNormalized.ts
+++ b/lib/JsonLdContextNormalized.ts
@@ -1,5 +1,4 @@
 import {resolve} from "relative-to-absolute-iri";
-import {defaultExpandOptions, IExpandOptions} from "./ContextParser";
 import {ERROR_CODES, ErrorCoded} from "./ErrorCoded";
 import {IJsonLdContextNormalizedRaw} from "./JsonLdContext";
 import {Util} from "./Util";
@@ -176,3 +175,25 @@ export class JsonLdContextNormalized {
   }
 
 }
+
+export interface IExpandOptions {
+  /**
+   * If compact IRI prefixes can end with any kind of character in simple term definitions,
+   * instead of only the default gen-delim characters (:,/,?,#,[,],@).
+   */
+  allowPrefixNonGenDelims: boolean;
+  /**
+   * If compact IRI prefixes ending with a non-gen-delim character
+   * can be forced as a prefix using @prefix: true.
+   */
+  allowPrefixForcing: boolean;
+  /**
+   * If @vocab values are allowed contain IRIs relative to @base.
+   */
+  allowVocabRelativeToBase: boolean;
+}
+export const defaultExpandOptions: IExpandOptions = {
+  allowPrefixForcing: true,
+  allowPrefixNonGenDelims: false,
+  allowVocabRelativeToBase: true,
+};

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -1,4 +1,4 @@
-import {IExpandOptions} from "./ContextParser";
+import {IExpandOptions} from "./JsonLdContextNormalized";
 import {IJsonLdContextNormalizedRaw, JsonLdContext} from "./JsonLdContext";
 
 export class Util {

--- a/test/JsonLdContextNormalized-test.ts
+++ b/test/JsonLdContextNormalized-test.ts
@@ -1,4 +1,4 @@
-import {defaultExpandOptions} from "../lib/ContextParser";
+import {defaultExpandOptions} from "../lib/JsonLdContextNormalized";
 import {ERROR_CODES, ErrorCoded} from "../lib/ErrorCoded";
 import {JsonLdContextNormalized} from "../lib/JsonLdContextNormalized";
 


### PR DESCRIPTION
Fixes a circular dependency described in this issue: https://github.com/rubensworks/jsonld-context-parser.js/issues/63 .  The circular dependency is creating build issues in some projects.  This PR:

- Moves some assets out of ContextParser.ts and into JsonLdContextNormalized.ts to fix circular dependency between the two.
- Updates import paths for other files using these assets.
- Ensures unit tests are still passing.