### PR TITLE
Fix handling of protected prefixes

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -791,7 +791,6 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
 
       // In JSON-LD 1.1, check if we are not redefining any protected keywords
       if (!ignoreProtection && parentContext && processingMode >= 1.1) {
-        // FIXME: See why version conflicts aren't being complained about here
         this.validateKeywordRedefinitions(parentContext, newContext, defaultExpandOptions);
       }
 

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -760,14 +760,14 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
         }
       }
 
-      // Merge different parts of the final context in order
-      this.applyScopedProtected(context, { processingMode }, defaultExpandOptions);
+      this.applyScopedProtected(importContext, { processingMode }, defaultExpandOptions);
+      let newContext: IJsonLdContextNormalizedRaw = { ...importContext, ...context };
+      if (typeof parentContext === 'object') {
+        // Merge different parts of the final context in order
+        this.applyScopedProtected(newContext, { processingMode }, defaultExpandOptions);
+        newContext = { ...parentContext, ...newContext };
+      }
 
-      const newContext: IJsonLdContextNormalizedRaw = {
-        ...(typeof parentContext === 'object' ? parentContext : {}),
-        ...importContext,
-        ...context,
-      };
       const newContextWrapped = new JsonLdContextNormalized(newContext);
 
       // Parse inner contexts with minimal processing

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -293,7 +293,6 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
           contextAfter[key] = { '@id': contextAfter[key] };
         }
 
-
         // Convert term values to strings for each comparison
         const valueBefore = canonicalizeJson(contextBefore[key]);
         // We modify this deliberately,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test": "jest ${1}",
     "test-watch": "jest ${1} --watch",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
-    "lint": "tslint index.ts lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "lint": "tslint index.ts lib/**/*.ts test/**/*.ts test/*.ts --exclude '**/*.d.ts'",
     "build": "tsc",
     "build-watch": "tsc --watch",
     "validate": "npm ls",

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -2199,8 +2199,6 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
       it('protected context should override the unprotected context', () => {
         return expect(parser.parse([
           {
-            // NOTE: This gets elevated to 1.1; when the contexts get merged.
-            // We should add a test here which uses a 1.0 specific feature.
             "@version": 1.0,
             "VerifiableCredential":"https://example.org/ns/"
           },

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -2135,8 +2135,6 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
       it('should parse 2 contexts where one is protected', () => {
         return expect(parser.parse([
           {
-            // NOTE: This gets elevated to 1.1; when the contexts get merged.
-            // We should add a test here which uses a 1.0 specific feature.
             "@version": 1.0,
             "ex":"https://example.org/ns/"
           },

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -2172,8 +2172,6 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
 
       const result = new JsonLdContextNormalized({
         "@version": 1.1,
-        // FIXME: See why there is an explicit false in the normalized context. I would think that this could
-        // just be deleted
         "@protected": false,
         VerifiableCredential: {
           "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",


### PR DESCRIPTION
Fixes https://github.com/rubensworks/jsonld-streaming-parser.js/issues/112
Fixes https://github.com/rubensworks/jsonld-streaming-parser.js/issues/117

Supercedes https://github.com/rubensworks/jsonld-context-parser.js/pull/61.

This has been tested against https://github.com/rubensworks/jsonld-streaming-parser.js. I have additional test cases which I will PR to that library once this patch is released. 
