### PR TITLE
fix: check value is a string in isSimpleTermDefinitionPrefix

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -252,7 +252,7 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
           }
 
           if (!Util.isPotentialKeyword(key) && !Util.isTermProtected(context, key)) {
-            const value = context[key];
+            const value: unknown = context[key];
             if (value && typeof value === 'object') {
               if (!('@protected' in context[key])) {
                 // Mark terms with object values as protected if they don't have an @protected: false annotation

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -156,9 +156,9 @@ export class Util {
    * @param value A simple term definition value.
    * @param options Options that define the way how expansion must be done.
    */
-  public static isSimpleTermDefinitionPrefix(value: string, options: IExpandOptions): boolean {
+  public static isSimpleTermDefinitionPrefix(value: unknown, options: IExpandOptions): boolean {
     return !Util.isPotentialKeyword(value)
-      && (value[0] === '_' || options.allowPrefixNonGenDelims || Util.isPrefixIriEndingWithGenDelim(value));
+      && (options.allowPrefixNonGenDelims || (typeof value === 'string' && (value[0] === '_' || Util.isPrefixIriEndingWithGenDelim(value))));
   }
 
   /**

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -2418,6 +2418,21 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
           ERROR_CODES.PROTECTED_TERM_REDEFINITION));
       });
 
+      it('should error on a protected null term with override', () => {
+        return expect(parser.parse([
+          {
+            "@version": 1.1,
+            "@protected": true,
+            "term": null
+          }, {
+            "@version": 1.1,
+            "term": {"@id": "http://example.com/term"}
+          }
+        ], { processingMode: 1.1 })).rejects.toThrow(new ErrorCoded(
+          'Attempted to override the protected keyword term from null to \"http://example.com/term\"',
+          ERROR_CODES.PROTECTED_TERM_REDEFINITION));
+      });
+
       it('should error on a protected term with override when the overriding version is 1.0', () => {
         return expect(parser.parse([
           {


### PR DESCRIPTION
Fixes the spec test error seen in https://github.com/rubensworks/jsonld-streaming-parser.js/pull/113.

@rubensworks note that an observation here is that since https://github.com/rubensworks/jsonld-context-parser.js/pull/65 we are now normalizing 

```json
{
  "@version": 1.1,
  "@protected": true,
  "term": null
}
```

as

```json
{
  "@version": 1.1,
  "term": {
    "@id": null,
    "@protected": true,
  }
}
```
which I'm not sure is correct...