### PR TITLE
perf: no deep cloning

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -863,8 +863,8 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
    * @param importContextIri The full URI of an @import value.
    */
   public async loadImportContext(importContextIri: string): Promise<IJsonLdContextNormalizedRaw> {
-    // Load the context
-    const importContext = await this.load(importContextIri);
+    // Load the context - and do a deep clone since we are about to mutate it
+    const importContext = JSON.parse(JSON.stringify(await this.load(importContextIri)));
 
     // Require the context to be a non-array object
     if (typeof importContext !== 'object' || Array.isArray(importContext)) {

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -179,7 +179,10 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
               && (!value['@container'] || !(<any> value['@container'])['@type'])
               && canAddIdEntry) {
               // First check @vocab, then fallback to @base
-              const expandedType = context.expandTerm(type, !(expandContentTypeToBase && type === contextRaw[key]['@type']));
+              let expandedType = context.expandTerm(type, true);
+              if (expandContentTypeToBase && type === expandedType) {
+                expandedType = context.expandTerm(type, false);
+              }
               if (expandedType !== type) {
                 changed = true;
                 contextRaw[key] = { ...contextRaw[key], '@type': expandedType };

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -724,7 +724,7 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
       }
 
       // Make a deep clone of the given context, to avoid modifying it.
-      context = <IJsonLdContextNormalizedRaw> {...context}; // No better way in JS at the moment.
+      context = <IJsonLdContextNormalizedRaw> {...context};
       if (parentContext && !minimalProcessing) {
         parentContext = <IJsonLdContextNormalizedRaw> {...parentContext};
       }


### PR DESCRIPTION
An alternative to #71 which removes the need for any deep cloning.

All unit & spec tests in the `jsonld-streaming-parser` pass with these changes.

I have also done a (small) benchmark of these changes. As can be seen the time taken to parse a context with these changes significantly decreases.

Before:
Parse a context that has not been cached; and without caching in place x 78.17 ops/sec ±0.73% (78 runs sampled)
Parse a context object that has not been cached x 2,280 ops/sec ±0.65% (91 runs sampled)

After:
Parse a context that has not been cached; and without caching in place x 123 ops/sec ±0.78% (84 runs sampled)
Parse a context object that has not been cached x 5,417 ops/sec ±0.70% (87 runs sampled)