### PR TITLE
perf: remove unnecessary cloning and iteration

### DIFF
--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -863,8 +863,8 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
    * @param importContextIri The full URI of an @import value.
    */
   public async loadImportContext(importContextIri: string): Promise<IJsonLdContextNormalizedRaw> {
-    // Load the context
-    const importContext = await this.load(importContextIri);
+    // Load the context - and do a deep clone since we are about to mutate it
+    const importContext = JSON.parse(JSON.stringify(await this.load(importContextIri)));
 
     // Require the context to be a non-array object
     if (typeof importContext !== 'object' || Array.isArray(importContext)) {

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -117,14 +117,9 @@ export class ContextParser {
    * @param {boolean} expandContentTypeToBase If @type inside the context may be expanded
    *                                          via @base if @vocab is set to null.
    */
-  public expandPrefixedTerms(
-    context: JsonLdContextNormalized,
-    expandContentTypeToBase: boolean,
-    /* istanbul ignore next */
-    keys = Object.keys(context.getContextRaw()
-    )) {
+  public expandPrefixedTerms(context: JsonLdContextNormalized, expandContentTypeToBase: boolean, keys?: string[]) {
     const contextRaw = context.getContextRaw();
-    for (const key of keys) {
+    for (const key of (keys || Object.keys(contextRaw))) {
       // Only expand allowed keys
       if (Util.EXPAND_KEYS_BLACKLIST.indexOf(key) < 0 && !Util.isReservedInternalKeyword(key)) {
         // Error if we try to alias a keyword to something else.
@@ -245,7 +240,6 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
         }
       }
     }
-    return context;
   }
 
   /**
@@ -293,10 +287,9 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
    */
   public validateKeywordRedefinitions(contextBefore: IJsonLdContextNormalizedRaw,
                                       contextAfter: IJsonLdContextNormalizedRaw,
-                                      expandOptions: IExpandOptions,
-                                      /* istanbul ignore next */
-                                      keys = Object.keys(contextAfter)) {
-    for (const key of keys) {
+                                      expandOptions?: IExpandOptions,
+                                      keys?: string[]) {
+    for (const key of (keys ?? Object.keys(contextAfter) )) {
       if (Util.isTermProtected(contextBefore, key)) {
         // The entry in the context before will always be in object-mode
         // If the new entry is in string-mode, convert it to object-mode
@@ -603,14 +596,8 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
    * @param {IParseOptions} options Parsing options.
    * @return {IJsonLdContextNormalizedRaw} The mutated input context.
    */
-  public async parseInnerContexts(
-    context: IJsonLdContextNormalizedRaw,
-    options: IParseOptions,
-    /* istanbul ignore next */
-    keys = Object.keys(context)
-    )
-    : Promise<IJsonLdContextNormalizedRaw> {
-    for (const key of keys) {
+  public async parseInnerContexts(context: IJsonLdContextNormalizedRaw, options: IParseOptions, keys?: string[]): Promise<IJsonLdContextNormalizedRaw> {
+    for (const key of (keys ?? Object.keys(context))) {
       const value = context[key];
       if (value && typeof value === 'object') {
         if ('@context' in value && value['@context'] !== null && !options.ignoreScopedContexts) {
@@ -743,7 +730,7 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
 
       // Hashify container entries
       // Do this before protected term validation as that influences term format
-      context = this.containersToHash(context);
+      this.containersToHash(context);
 
       // Don't perform any other modifications if only minimal processing is needed.
       if (minimalProcessing) {
@@ -809,8 +796,7 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
         }
       }
 
-      // FIXME: Add keys as a 3rd argument here for performance
-      this.expandPrefixedTerms(newContextWrapped, this.expandContentTypeToBase);
+      this.expandPrefixedTerms(newContextWrapped, this.expandContentTypeToBase, keys);
 
       // In JSON-LD 1.1, check if we are not redefining any protected keywords
       if (!ignoreProtection && parentContext && processingMode >= 1.1) {
@@ -901,7 +887,8 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
 
     // Containers have to be converted into hash values the same way as for the importing context
     // Otherwise context validation will fail for container values
-    return this.containersToHash(importContext);
+    this.containersToHash(importContext);
+    return importContext;
   }
 
 }

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -5,23 +5,7 @@ import {FetchDocumentLoader} from "./FetchDocumentLoader";
 import {IDocumentLoader} from "./IDocumentLoader";
 import {IJsonLdContext, IJsonLdContextNormalizedRaw, IPrefixValue, JsonLdContext} from "./JsonLdContext";
 import {JsonLdContextNormalized, defaultExpandOptions, IExpandOptions} from "./JsonLdContextNormalized";
-import {Util} from "./Util";
-
-const deepEqual = (object1: any, object2: any): boolean => {
-  const objKeys1 = Object.keys(object1);
-  const objKeys2 = Object.keys(object2);
-
-  if (objKeys1.length !== objKeys2.length) return false;
-  return objKeys1.every((key) => {
-    const value1 = object1[key];
-    const value2 = object2[key];
-    return (value1 === value2) || (isObject(value1) && isObject(value2) && deepEqual(value1, value2));
-  });
-};
-
-const isObject = (object: any) => {
-  return object != null && typeof object === "object";
-};
+import {Util,deepEqual} from "./Util";
 
 /**
  * Parses JSON-LD contexts.

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -599,6 +599,8 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
    * @param {IJsonLdContextNormalizedRaw} context A context.
    * @param {IParseOptions} options Parsing options.
    * @return {IJsonLdContextNormalizedRaw} The mutated input context.
+   * @param {string[]} keys Optional set of keys from the context to parseInnerContexts of. If left undefined, all
+   * keys in the context will be iterated over.
    */
   public async parseInnerContexts(context: IJsonLdContextNormalizedRaw, options: IParseOptions, keys?: string[]): Promise<IJsonLdContextNormalizedRaw> {
     for (const key of (keys ?? Object.keys(context))) {

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -786,7 +786,7 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
 
       this.applyScopedProtected(importContext, { processingMode }, defaultExpandOptions);
 
-      let newContext: IJsonLdContextNormalizedRaw = { ...importContext, ...context };
+      const newContext: IJsonLdContextNormalizedRaw = Object.assign(importContext, context);
 
       // Handle terms (before protection checks)
       this.idifyReverseTerms(newContext);
@@ -796,7 +796,11 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
       const keys = Object.keys(newContext);
       if (typeof parentContext === 'object') {
         // Merge different parts of the final context in order
-        newContext = { ...parentContext, ...newContext };
+        for (const key in parentContext) {
+          if (!(key in newContext)) {
+            newContext[key] = parentContext[key];
+          }
+        }
       }
 
       // Parse inner contexts with minimal processing

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -179,7 +179,10 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
               && (!value['@container'] || !(<any> value['@container'])['@type'])
               && canAddIdEntry) {
               // First check @vocab, then fallback to @base
-              const expandedType = context.expandTerm(type, !(expandContentTypeToBase && type === contextRaw[key]['@type']));
+              let expandedType = context.expandTerm(type, true);
+              if (expandContentTypeToBase && type === expandedType) {
+                expandedType = context.expandTerm(type, false);
+              }
               if (expandedType !== type) {
                 changed = true;
                 contextRaw[key] = { ...contextRaw[key], '@type': expandedType };

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -5,7 +5,7 @@ import {FetchDocumentLoader} from "./FetchDocumentLoader";
 import {IDocumentLoader} from "./IDocumentLoader";
 import {IJsonLdContext, IJsonLdContextNormalizedRaw, IPrefixValue, JsonLdContext} from "./JsonLdContext";
 import {JsonLdContextNormalized, defaultExpandOptions, IExpandOptions} from "./JsonLdContextNormalized";
-import {Util,deepEqual} from "./Util";
+import {Util} from "./Util";
 
 /**
  * Parses JSON-LD contexts.
@@ -116,6 +116,8 @@ export class ContextParser {
    * @param {IJsonLdContextNormalizedRaw} context A context.
    * @param {boolean} expandContentTypeToBase If @type inside the context may be expanded
    *                                          via @base if @vocab is set to null.
+   * @param {string[]} keys Optional set of keys from the context to expand. If left undefined, all
+   * keys in the context will be expanded.
    */
   public expandPrefixedTerms(context: JsonLdContextNormalized, expandContentTypeToBase: boolean, keys?: string[]) {
     const contextRaw = context.getContextRaw();
@@ -284,6 +286,8 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
    * @param {IJsonLdContextNormalizedRaw} contextBefore The context that may contain some protected terms.
    * @param {IJsonLdContextNormalizedRaw} contextAfter A new context that is being applied on the first one.
    * @param {IExpandOptions} expandOptions Options that are needed for any expansions during this validation.
+   * @param {string[]} keys Optional set of keys from the context to validate. If left undefined, all
+   * keys defined in contextAfter will be checked.
    */
   public validateKeywordRedefinitions(contextBefore: IJsonLdContextNormalizedRaw,
                                       contextAfter: IJsonLdContextNormalizedRaw,
@@ -304,7 +308,7 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
         }
 
         // Error if they are not identical
-        if (!deepEqual(contextBefore[key], contextAfter[key])) {
+        if (!Util.deepEqual(contextBefore[key], contextAfter[key])) {
           throw new ErrorCoded(`Attempted to override the protected keyword ${key} from ${
             JSON.stringify(Util.getContextValueId(contextBefore[key]))} to ${
             JSON.stringify(Util.getContextValueId(contextAfter[key]))}`,

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -724,7 +724,7 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
       }
 
       // Make a deep clone of the given context, to avoid modifying it.
-      context = <IJsonLdContextNormalizedRaw> {...context}; // No better way in JS at the moment.
+      context = <IJsonLdContextNormalizedRaw> {...context};
       if (parentContext && !minimalProcessing) {
         parentContext = <IJsonLdContextNormalizedRaw> {...parentContext};
       }

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -120,7 +120,12 @@ export class ContextParser {
    * @param {boolean} expandContentTypeToBase If @type inside the context may be expanded
    *                                          via @base if @vocab is set to null.
    */
-  public expandPrefixedTerms(context: JsonLdContextNormalized, expandContentTypeToBase: boolean, keys = Object.keys(context.getContextRaw())) {
+  public expandPrefixedTerms(
+    context: JsonLdContextNormalized,
+    expandContentTypeToBase: boolean,
+    /* istanbul ignore next */
+    keys = Object.keys(context.getContextRaw()
+    )) {
     const contextRaw = context.getContextRaw();
     for (const key of keys) {
       // Only expand allowed keys
@@ -291,7 +296,9 @@ Tried mapping ${key} to ${JSON.stringify(keyValue)}`, ERROR_CODES.INVALID_KEYWOR
    */
   public validateKeywordRedefinitions(contextBefore: IJsonLdContextNormalizedRaw,
                                       contextAfter: IJsonLdContextNormalizedRaw,
-                                      expandOptions: IExpandOptions, keys = Object.keys(contextAfter)) {
+                                      expandOptions: IExpandOptions,
+                                      /* istanbul ignore next */
+                                      keys = Object.keys(contextAfter)) {
     for (const key of Object.keys(contextAfter)) {
       if (Util.isTermProtected(contextBefore, key)) {
         // The entry in the context before will always be in object-mode
@@ -602,7 +609,12 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
    * @param {IParseOptions} options Parsing options.
    * @return {IJsonLdContextNormalizedRaw} The mutated input context.
    */
-  public async parseInnerContexts(context: IJsonLdContextNormalizedRaw, options: IParseOptions, keys = Object.keys(context))
+  public async parseInnerContexts(
+    context: IJsonLdContextNormalizedRaw,
+    options: IParseOptions,
+    /* istanbul ignore next */
+    keys = Object.keys(context)
+    )
     : Promise<IJsonLdContextNormalizedRaw> {
     for (const key of keys) {
       const value = context[key];

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -663,14 +663,13 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
                      options: IParseOptions = {}, ioptions: { skipValidation?: boolean } = {}): Promise<JsonLdContextNormalized> {
     const {
       baseIRI,
-      parentContext: parentContextInitial,
+      parentContext,
       external,
       processingMode = ContextParser.DEFAULT_PROCESSING_MODE,
       normalizeLanguageTags,
       ignoreProtection,
       minimalProcessing,
     } = options;
-    let parentContext = parentContextInitial;
     const remoteContexts = options.remoteContexts || {};
 
     // Avoid remote context overflows
@@ -748,9 +747,6 @@ must be one of ${Util.CONTAINERS.join(', ')}`, ERROR_CODES.INVALID_CONTAINER_MAP
 
       // Make a deep clone of the given context, to avoid modifying it.
       context = <IJsonLdContextNormalizedRaw> {...context};
-      if (parentContext && !minimalProcessing) {
-        parentContext = <IJsonLdContextNormalizedRaw> {...parentContext};
-      }
 
       // According to the JSON-LD spec, @base must be ignored from external contexts.
       if (external) {
@@ -1003,4 +999,3 @@ export interface IParseOptions {
    */
   ignoreScopedContexts?: boolean;
 }
-

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -248,3 +248,18 @@ export class Util {
     return key.startsWith('@__');
   }
 }
+
+export const deepEqual = (object1: any, object2: any): boolean => {
+  const objKeys1 = Object.keys(object1);
+  const objKeys2 = Object.keys(object2);
+
+  if (objKeys1.length !== objKeys2.length) return false;
+  return objKeys1.every((key) => {
+    const value1 = object1[key];
+    const value2 = object2[key];
+    return (value1 === value2) || (isObject(value1) && isObject(value2) && deepEqual(value1, value2));
+  });
+};
+const isObject = (object: any) => {
+  return object !== null && typeof object === "object";
+};

--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -247,19 +247,27 @@ export class Util {
   public static isReservedInternalKeyword(key: string) {
     return key.startsWith('@__');
   }
+
+  /**
+   * Check if two objects are deepEqual to on another.
+   * @param object1 The first object to test.
+   * @param object2 The second object to test.
+   */
+  public static deepEqual(object1: any, object2: any): boolean {
+    const objKeys1 = Object.keys(object1);
+    const objKeys2 = Object.keys(object2);
+
+    if (objKeys1.length !== objKeys2.length) return false;
+    return objKeys1.every((key) => {
+      const value1 = object1[key];
+      const value2 = object2[key];
+      return (value1 === value2) || (
+        value1 !== null &&
+        value2 !== null &&
+        typeof value1 === "object" &&
+        typeof value2 === "object" &&
+        this.deepEqual(value1, value2)
+      );
+    });
+  };
 }
-
-export const deepEqual = (object1: any, object2: any): boolean => {
-  const objKeys1 = Object.keys(object1);
-  const objKeys2 = Object.keys(object2);
-
-  if (objKeys1.length !== objKeys2.length) return false;
-  return objKeys1.every((key) => {
-    const value1 = object1[key];
-    const value2 = object2[key];
-    return (value1 === value2) || (isObject(value1) && isObject(value2) && deepEqual(value1, value2));
-  });
-};
-const isObject = (object: any) => {
-  return object !== null && typeof object === "object";
-};

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
   "dependencies": {
     "@types/http-link-header": "^1.0.1",
     "@types/node": "^18.0.0",
-    "canonicalize": "^1.0.1",
     "cross-fetch": "^3.0.6",
     "http-link-header": "^1.0.2",
     "relative-to-absolute-iri": "^1.0.5"

--- a/test/ContextParser-test.ts
+++ b/test/ContextParser-test.ts
@@ -3534,7 +3534,7 @@ Tried mapping @id to {}`, ERROR_CODES.KEYWORD_REDEFINITION));
       });
     });
 
-    describe('#validateKeyowrdRedefinitions', () => {
+    describe('#validateKeywordRedefinitions', () => {
       it('should return true when validating over the same context', async () => {
         const context = new JsonLdContextNormalized({
           '@base': 'http://base.org/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,11 +1137,6 @@ caniuse-lite@^1.0.30001359:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz#26bec2d606924ba318235944e1193304ea7c4f15"
   integrity sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==
 
-canonicalize@^1.0.1:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
-  integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
This PR:
  1. Fixes a bug where cached document contexts were being mutated if they were being loaded via in `@import` statement (#71 was originally opened to resolve this).
  2. Removes all deep cloning to improve performance (#72 was originally opened to resolve this)
  3. Skips applying idempotent operations to the parent.

All unit & spec tests in the `jsonld-streaming-parser` pass with these changes (tested against https://github.com/rubensworks/jsonld-context-parser.js/pull/73/commits/bce9e05d40adecdb7c34d26a4bce8d779dfebdbb).

I have also done a (small) benchmark of these changes. As can be seen the time taken to parse a context with these changes significantly decreases (in particular it is now **20**x faster to parse a VC context).

Before:
Parse a context that has not been cached; and without caching in place x **78.17** ops/sec ±0.73% (78 runs sampled)
Parse a context object that has not been cached x **2,280** ops/sec ±0.65% (91 runs sampled)

in #72:
Parse a context that has not been cached; and without caching in place x **123** ops/sec ±0.78% (84 runs sampled)
Parse a context object that has not been cached x **5,417** ops/sec ±0.70% (87 runs sampled)

After (in this PR):
Parse a context that has not been cached; and without caching in place x **1,714** ops/sec ±0.78% (84 runs sampled)
Parse a context object that has not been cached x **8,902** ops/sec ±0.70% (87 runs sampled)

Let's get this merged and then I'll revisit #70 to see what is actually worth caching.
