### PR TITLE
BREAKING: remove cross fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - 12.x
-          - 14.x
-          - 16.x
           - 18.x
           - 20.x
           - 22.x

--- a/lib/ContextParser.ts
+++ b/lib/ContextParser.ts
@@ -1,4 +1,3 @@
-import 'cross-fetch/polyfill';
 import {resolve} from "relative-to-absolute-iri";
 import {ERROR_CODES, ErrorCoded} from "./ErrorCoded";
 import {FetchDocumentLoader} from "./FetchDocumentLoader";

--- a/lib/FetchDocumentLoader.ts
+++ b/lib/FetchDocumentLoader.ts
@@ -1,4 +1,3 @@
-import 'cross-fetch/polyfill';
 import {IDocumentLoader} from "./IDocumentLoader";
 import {IJsonLdContext} from "./JsonLdContext";
 import {ERROR_CODES, ErrorCoded} from "./ErrorCoded";

--- a/package.json
+++ b/package.json
@@ -88,8 +88,5 @@
     "@types/node": "^18.0.0",
     "http-link-header": "^1.0.2",
     "relative-to-absolute-iri": "^1.0.5"
-  },
-  "engines": {
-    "node": ">=18.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,8 +86,10 @@
   "dependencies": {
     "@types/http-link-header": "^1.0.1",
     "@types/node": "^18.0.0",
-    "cross-fetch": "^3.0.6",
     "http-link-header": "^1.0.2",
     "relative-to-absolute-iri": "^1.0.5"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/setupJest.js
+++ b/setupJest.js
@@ -1,5 +1,3 @@
-require('cross-fetch/polyfill');
-
 // Mock fetch to our local files
 global.fetch = jest.fn().mockImplementation((url) => {
   let data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,13 +1296,6 @@ coveralls@^3.0.0:
     minimist "^1.2.5"
     request "^2.88.2"
 
-cross-fetch@^3.0.6:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2617,13 +2610,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3409,11 +3395,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
@@ -3613,11 +3594,6 @@ watchpack@^2.3.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
 webpack-cli@^4.10.0:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
@@ -3678,14 +3654,6 @@ webpack@^5.73.0:
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.3.1"
     webpack-sources "^3.2.3"
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which@1.2.x:
   version "1.2.14"


### PR DESCRIPTION
Removes the cross fetch function in favour of using the global fetch function. Needed in order to ensure that the tests in https://github.com/comunica/comunica/pull/1372 passes offline.