### PR TITLE
Add very basic Playground to harden contexts.

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,0 +1,36 @@
+name: Publish site
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Bundle library for playground
+      run: |
+        npm run bundle
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      with:
+        path: docs/
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write    # to deploy to Pages
+      id-token: write # to verify deployment originates from an appropriate source
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 **/index.d.ts
 coverage
 documentation
+docs/bundle.js

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,53 @@
+import {createApp} from 'https://unpkg.com/petite-vue?module';
+import {ContextParser} from './bundle.js';
+
+createApp({
+  // data
+  contextString: JSON.stringify([
+    {
+      "@vocab": "http://vocab.org/",
+      "npmd": "https://linkedsoftwaredependencies.org/bundles/npm/",
+      "p": { "@id": "pred1", "@language": "nl" }
+    }
+  ], null, 2),
+  hardenedContext: "",
+  filename: "",
+  parseError: "",
+
+  async updateHardenedContext() {
+    const parser = new ContextParser();
+    const {contextRaw} = await parser.parse(JSON.parse(this.contextString));
+    this.hardenedContext = JSON.stringify(contextRaw, null, 2);
+  },
+
+  // methods
+  async pickFile() {
+    const [fileHandle] = await window.showOpenFilePicker();
+    this.filename = fileHandle.name;
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    try {
+      this.contextString = text;
+      this.setHardenedContext(JSON.parse(text));
+      this.parseError = "";
+    } catch(error) {
+      // TODO: error on selected files should be reported somewhere else
+      // ...and be blocking...
+      this.parseError = error.message;
+      console.error(error);
+    };
+  },
+  getContext($event) {
+    try {
+      this.setHardenedContext(JSON.parse($event.target.value));
+      this.parseError = "";
+    } catch(error) {
+      this.parseError = error.message;
+      console.error(error);
+    }
+  },
+  setHardenedContext(context) {
+    console.log('Setting hardened context', context);
+    this.hardenedContext = JSON.stringify(context, null, 2);
+  }
+}).mount();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,46 @@
+<html>
+  <head>
+    <title>JSON-LD Context Hardener</title>
+    <meta http-equiv="content-security-policy" content="frame-src 'none'">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/fomantic-ui/2.9.0/semantic.min.css" integrity="sha512-PwhgdrueUt7iVICnZMjYcbiLalCztrVfzUIYXekIK8hZu4DQP141GrKh6fUHmNERWi4bGdBXIZqtBZnsSzHEMg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/4.1.0/mustache.min.js" integrity="sha512-HYiNpwSxYuji84SQbCU5m9kHEsRqwWypXgJMBtbRSumlx1iBB6QaxgEBZHSHEGM+fKyCX/3Kb5V5jeVXm0OglQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="module">
+      import './app.js';
+    </script>
+    <style>
+      .main.grid { padding-top: 3em !important }
+      .main.grid > .row { padding-top: 1.4em !important }
+      .main.grid, .main.grid .ui.form, .main.grid .ui.form .field, .main.grid .ui.form .field textarea { height: stretch; max-height: none; }
+    </style>
+    </head>
+  <body>
+    <div class="ui fixed top menu">
+      <div class="item">
+        <button class="ui button" @click="pickFile()">Choose Context...</button>
+      </div>
+      <div class="disabled item" v-show="filename" v-text="filename"></div>
+    </div>
+
+    <main class="ui main very compact grid" v-scope @vue:mounted="updateHardenedContext()">
+      <div class="row">
+        <div class="eight wide column">
+          <div class="ui form">
+            <div class="field">
+              <label class="ui top attached label">Original Context</label>
+              <textarea ref="input" v-model="contextString" @input="updateHardenedContext()" placeholder="JSON-LD Context"></textarea>
+            </div>
+            <div class="ui error message" :class="{ visible: parseError.length > 0 }" v-text="parseError"></div>
+          </div>
+        </div>
+        <div class="eight wide column">
+          <div class="ui form">
+            <div class="field">
+              <label class="ui top attached label">Hardened Context</label>
+              <textarea v-model="hardenedContext" readonly></textarea>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "lint": "tslint index.ts lib/**/*.ts test/**/*.ts test/*.ts --exclude '**/*.d.ts'",
     "build": "tsc",
-    "build-watch": "tsc --watch",
+    "build-watch": "tsc --watch" ,
+    "bundle": "esbuild index.ts --format=esm --bundle --outfile=docs/bundle.js",
     "validate": "npm ls",
     "prepare": "npm run build",
     "version": "manual-git-changelog onversion"


### PR DESCRIPTION
The playground is build with `petite-vue` with the parser bundled via
`esbuild index.ts --format=esm --bundle --outfile=docs/bundle.js`

The `docs/` folder is intended to be hosted via GitHub Pages.

Here's a demo hosted via GitHub Pages on my fork: https://bigbluehat.github.io/jsonld-context-parser.js/

Relates to https://github.com/w3c/json-ld-bp/issues/19