### PR TITLE
Move @types packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   },
   "sideEffects": false,
   "devDependencies": {
+    "@types/http-link-header": "^1.0.1",
     "@types/jest": "^30.0.0",
+    "@types/node": "^24.0.0",
     "coveralls": "^3.0.0",
     "jest": "^30.0.0",
     "manual-git-changelog": "^1.0.0",
@@ -88,8 +90,6 @@
     "version": "manual-git-changelog onversion"
   },
   "dependencies": {
-    "@types/http-link-header": "^1.0.1",
-    "@types/node": "^24.0.0",
     "http-link-header": "^1.0.2",
     "relative-to-absolute-iri": "^1.0.5"
   }


### PR DESCRIPTION
Every consumer currently installs `@types/node` (~2.5 MB) and `@types/http-link-header` at runtime, and nothing in the published output needs them:

- No `.d.ts` in the tarball mentions `Buffer`, `NodeJS.*` or any other Node global, and none carries a `/// <reference types="node" />`; none refers to `http-link-header`’s types either.
- The only Node built-in used at runtime is `fs`, in `bin/jsonld-context-parse.js` – plain JavaScript, no types involved.
- A consumer compiles the published typings with `"types": []` and `"skipLibCheck": false`, and `tsc` exits 0.

`npm run build` and the 482 tests pass unchanged.

Found while trimming a production Docker image, where `@types/node` was among the larger packages in a tree that never type-checks anything.
